### PR TITLE
Change app-header z-index to be below modals

### DIFF
--- a/com.dangeredwolf.TweetDeckEnhancer.safariextension/sources/app-dark.css
+++ b/com.dangeredwolf.TweetDeckEnhancer.safariextension/sources/app-dark.css
@@ -7320,7 +7320,7 @@ img.spinner-centered {
   user-select:none;
   width:200px;
   background-color: rgba(0, 0, 0, 0.1);
-  z-index: 9999999999999999999;
+  z-index: 299;
   pointer-events: none;
 }
 

--- a/com.dangeredwolf.TweetDeckEnhancer.safariextension/sources/app-light.css
+++ b/com.dangeredwolf.TweetDeckEnhancer.safariextension/sources/app-light.css
@@ -7518,7 +7518,7 @@ i.icon.icon-move {
   user-select:none;
   width:200px;
   background-color: rgba(0, 0, 0, 0.1);
-  z-index: 9999999999999999999;
+  z-index: 299;
   pointer-events: none;
 }
 


### PR DESCRIPTION
I personally don't like the fact that the app bar is always on top, because it's not that important. Modals should stay on top of everything, so I just changed the z-index of the app-header.